### PR TITLE
Downcase keys in result row hash.

### DIFF
--- a/lib/schema_plus/views/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/schema_plus/views/active_record/connection_adapters/mysql2_adapter.rb
@@ -7,6 +7,7 @@ module SchemaPlus::Views
             results = select_all("SELECT view_definition, check_option FROM information_schema.views WHERE table_schema = SCHEMA() AND table_name = #{quote(view_name)}", name)
             if  results.any?
               row = results.first
+              row.transform_keys!(&:downcase)
               sql = row["view_definition"]
               sql.gsub!(%r{#{quote_table_name(current_database)}[.]}, '')
               case row["check_option"]


### PR DESCRIPTION
For me MySQL (Percona server 8.0.13) is returning all caps keys
in the result row hash:

```
[1] pry(#<ActiveRecord::ConnectionAdapters::Mysql2Adapter>)> row
=> {"VIEW_DEFINITION"=>
  "select .......
```
The result is that `db:schema:dump` is failing:

```
rails aborted!
NoMethodError: undefined method `gsub!' for nil:NilClass
/........./vendor/bundle/ruby/2.4.0/bundler/gems/schema_plus_views-71dce2030147/lib/schema_plus/views/active_record/connection_adapters/mysql2_adapter.rb:12:in `block in view_definition'
```